### PR TITLE
Ignore sdt eclipse-generated project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 key
 common/lib/
+common/.project
 player-desktop/lib
 libs/
 target/


### PR DESCRIPTION
I'm not sure if you don't want this to be added to the git repository, but judging from the ignore on the `.project` file in the root directory, it seems logical not to clutter other people's eclipse project settings into the master repo.

Feel free to deny this request if I made a mistake. 
