### PR TITLE
adjust database size + osx update

### DIFF
--- a/editor/src/main/scala/rpgboss/editor/dialog/DatabaseDialog.scala
+++ b/editor/src/main/scala/rpgboss/editor/dialog/DatabaseDialog.scala
@@ -12,10 +12,17 @@ import scala.swing._
 import scala.swing.event._
 import rpgboss.editor.Internationalized._
 
+import java.awt.Toolkit
+
 class DatabaseDialog(owner: Window, sm: StateMaster)
   extends StdDialog(owner, getMessage("Database")) {
 
-  centerDialog(new Dimension(1024, 600))
+  val screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+  if(screenSize.width > 1280 && screenSize.height > 900) {
+    centerDialog(new Dimension(screenSize.width/2, screenSize.height/2))
+  } else {
+    centerDialog(new Dimension(1024, 600))
+  }
 
   val model = Utils.deepCopy(sm.getProjData)
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -128,7 +128,7 @@ object Settings {
     
     // Declare names
     val gdxBaseUrl = "http://libgdx.badlogicgames.com/releases"
-    val gdxName = "libgdx-1.2.0"
+    val gdxName = "libgdx-1.5.0"
 
     // Fetch the file.
     val gdxZipName = "%s.zip" format(gdxName)


### PR DESCRIPTION
Adjust database window size for greater displays:
https://github.com/rpgboss/rpgboss/issues/184

Updating libgdx version to fix some display bugs on osx
![unbenannt-1](https://cloud.githubusercontent.com/assets/342368/5563648/affe911a-8e86-11e4-98ba-f58dfb88020e.jpg)

But now is this and i dont know how to position it.
