### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ http://rpgmakertimes.agilityhoster.com/2011/02/final-fantasy-i-xpvx-windowskin/
 LordSpirit.jpg:
 http://www.rpgrevolution.com/forums/index.php?autocom=gallery&req=si&img=3701
 
-###Battle Background
+### Battle Background
 
-#####Side View Battle Background
+##### Side View Battle Background
 
 Julian Xin raveolutionx@gmail.com (CC-BY 4.0)  http://creativecommons.org/licenses/by/4.0/
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
